### PR TITLE
Remove deprecated extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,10 +11,10 @@
         "redhat.vscode-yaml",
         "vscode-icons-team.vscode-icons",
         "Vue.volar",
-        "Vue.vscode-typescript-vue-plugin",
         "YoavBls.pretty-ts-errors"
       ],
       "settings": {
+        "redhat.telemetry.enabled": false,
         "vsicons.dontShowNewVersionMessage": true,
         "workbench.colorTheme": "Default Dark Modern",
         "workbench.iconTheme": "vscode-icons"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,11 +1,9 @@
 {
-	"recommendations": [
-		"editorconfig.editorconfig",
-		"dbaeumer.vscode-eslint",
-		"Vue.volar",
-		"Vue.vscode-typescript-vue-plugin",
-		"Orta.vscode-jest",
-		"dbaeumer.vscode-eslint",
-		"mrmlnc.vscode-json5"
-	]
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "dbaeumer.vscode-eslint",
+    "mrmlnc.vscode-json5",
+    "Orta.vscode-jest",
+    "Vue.volar"
+  ]
 }


### PR DESCRIPTION
The Volar and Vue.js TypeScript extension were merged into one extension, so having the old TS extension installed is unnecessary.