### PR TITLE
fix: correct name for source code hosting site

### DIFF
--- a/packages/frontend/src/pages/about-cutiekey.vue
+++ b/packages/frontend/src/pages/about-cutiekey.vue
@@ -51,7 +51,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 						<FormLink to="https://github.com/cutiekey/cutiekey" external>
 							<template #icon><i class="ph-code ph-bold ph-lg"></i></template>
 							{{ i18n.ts._aboutMisskey.source }} ({{ i18n.ts._aboutMisskey.original_cutiekey }})
-							<template #suffix>GitLab</template>
+							<template #suffix>GitHub</template>
 						</FormLink>
 					</div>
 				</FormSection>


### PR DESCRIPTION
cutiekey is saying that its repository is hosted on gitlab, but that's not true,