### PR TITLE
fix: jemalloc library file name in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ ARG UID="991"
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
   ffmpeg tini curl libjemalloc-dev libjemalloc2 \
-  && ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc2.so.2 /usr/local/lib/libjemalloc.so \
+  && ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so \
   && corepack enable \
   && groupadd -g "${GID}" cutiekey \
   && useradd -l -u "${UID}" -g "${GID}" -m -d /cutiekey cutiekey \


### PR DESCRIPTION
This matches Misskey's Dockerfile: https://github.com/misskey-dev/misskey/blob/develop/Dockerfile

Before that change the Docker image worked, but flooded the following into logs:

```
ERROR: ld.so: object '/usr/local/lib/libjemalloc.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
```

Tested this change on https://sylveon.social/.