### PR TITLE
Set default like to `❤️`

### DIFF
--- a/packages/backend/migration/1718954323620-set-default-like.js
+++ b/packages/backend/migration/1718954323620-set-default-like.js
@@ -1,0 +1,13 @@
+export class SetDefaultLike1718954323620 {
+    name = 'SetDefaultLike1718954323620'
+
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "meta" ALTER COLUMN "defaultLike" SET DEFAULT '❤️'`);
+        await queryRunner.query(`UPDATE "meta" SET "defaultLike" = '❤️' WHERE "defaultLike" IS NULL`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "meta" ALTER COLUMN "defaultLike" DROP DEFAULT`);
+    }
+
+}


### PR DESCRIPTION
`1710338421353-update-repository-urls.js` sets the default like to NULL, which i think is a mistake (`1710338421353-update-repository-urls.js` did quite a lot of changes, that i'm not sure were intentional)

the problem with setting this value to NULL is that the admin panel cannot handle it, and this results in default like field not appearing at all when it's set to NULL