### PR TITLE
prefer english strings over japanese for non-japanese locales

### DIFF
--- a/locales/index.js
+++ b/locales/index.js
@@ -93,8 +93,8 @@ export function build() {
 
           default:
             return merge(
-              locales['en-US'],
               locales['ja-JP'],
+              locales['en-US'],
               locales[`${lang}-${primaries[lang]}`] ?? {},
               v
             )


### PR DESCRIPTION
currently when dealing with languages other than english, cutiekey prefers japanese strings, which is non-ideal

it's more likely somebody will be able to read a string in english than japanese