### PR TITLE
Add a prometheus compatible endpoint

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -155,6 +155,7 @@
 		"pg": "8.12.0",
 		"pkce-challenge": "4.1.0",
 		"probe-image-size": "7.2.3",
+		"prom-client": "^15.1.3",
 		"promise-limit": "2.7.0",
 		"proxy-addr": "^2.0.7",
 		"pug": "3.0.3",

--- a/packages/backend/src/boot/worker.ts
+++ b/packages/backend/src/boot/worker.ts
@@ -9,7 +9,7 @@ import { nodeProfilingIntegration } from '@sentry/profiling-node';
 import { envOption } from '@/env.js';
 import { loadConfig } from '@/config.js';
 import { jobQueue, server } from './common.js';
-
+import { collectDefaultMetrics, AggregatorRegistry } from 'prom-client';
 /**
  * Init worker process
  */
@@ -33,6 +33,10 @@ export async function workerMain() {
 			...config.sentryForBackend.options,
 		});
 	}
+
+	// initialize prom-client in the worker
+	const aggregatorRegistry = new AggregatorRegistry();
+	collectDefaultMetrics();
 
 	if (envOption.onlyServer) {
 		await server();

--- a/packages/backend/src/misc/metrics.ts
+++ b/packages/backend/src/misc/metrics.ts
@@ -1,0 +1,7 @@
+import { register, Counter, Gauge } from 'prom-client'
+
+export const jobs_metrics = new Counter({
+	name: "sharkey_jobs",
+	help: "Metrics about jobs",
+	labelNames: ['job', 'status', 'reason'] as const,
+});

--- a/packages/backend/src/queue/QueueProcessorService.ts
+++ b/packages/backend/src/queue/QueueProcessorService.ts
@@ -6,6 +6,7 @@
 import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
 import * as Bull from 'bullmq';
 import * as Sentry from '@sentry/node';
+import { register, Gauge, Histogram } from 'prom-client';
 import type { Config } from '@/config.js';
 import { DI } from '@/di-symbols.js';
 import type Logger from '@/logger.js';
@@ -142,6 +143,19 @@ export class QueueProcessorService implements OnApplicationShutdown {
 			}
 		}
 
+		const histogram = new Histogram({
+			  name: 'sharkey_queue_timings',
+			  help: 'Timings of jobs per queue',
+			  labelNames: ['queue', 'job'] as const,
+			});
+
+		function runProcessorWithTimer(queue: String, processor: (job: Bull.Job) => void, job: Bull.Job) {
+			const end = histogram.startTimer();
+			processor(job);
+			end({queue, job: job.name});
+		}
+
+
 		//#region system
 		{
 			const processer = (job: Bull.Job) => {
@@ -160,7 +174,7 @@ export class QueueProcessorService implements OnApplicationShutdown {
 				if (this.config.sentryForBackend) {
 					return Sentry.startSpan({ name: 'Queue: System: ' + job.name }, () => processer(job));
 				} else {
-					return processer(job);
+					return runProcessorWithTimer('system', processer, job);
 				}
 			}, {
 				...baseQueueOptions(this.config, QUEUE.SYSTEM),
@@ -225,7 +239,7 @@ export class QueueProcessorService implements OnApplicationShutdown {
 				if (this.config.sentryForBackend) {
 					return Sentry.startSpan({ name: 'Queue: DB: ' + job.name }, () => processer(job));
 				} else {
-					return processer(job);
+					return runProcessorWithTimer('db', processer, job);
 				}
 			}, {
 				...baseQueueOptions(this.config, QUEUE.DB),
@@ -257,7 +271,7 @@ export class QueueProcessorService implements OnApplicationShutdown {
 				if (this.config.sentryForBackend) {
 					return Sentry.startSpan({ name: 'Queue: Deliver' }, () => this.deliverProcessorService.process(job));
 				} else {
-					return this.deliverProcessorService.process(job);
+					return runProcessorWithTimer('deliver', this.deliverProcessorService.process, job);
 				}
 			}, {
 				...baseQueueOptions(this.config, QUEUE.DELIVER),
@@ -297,7 +311,7 @@ export class QueueProcessorService implements OnApplicationShutdown {
 				if (this.config.sentryForBackend) {
 					return Sentry.startSpan({ name: 'Queue: Inbox' }, () => this.inboxProcessorService.process(job));
 				} else {
-					return this.inboxProcessorService.process(job);
+					return runProcessorWithTimer('inbox', this.inboxProcessorService.process, job);
 				}
 			}, {
 				...baseQueueOptions(this.config, QUEUE.INBOX),
@@ -337,7 +351,7 @@ export class QueueProcessorService implements OnApplicationShutdown {
 				if (this.config.sentryForBackend) {
 					return Sentry.startSpan({ name: 'Queue: UserWebhookDeliver' }, () => this.userWebhookDeliverProcessorService.process(job));
 				} else {
-					return this.userWebhookDeliverProcessorService.process(job);
+					return runProcessorWithTimer('userwebhookdeliver', this.userWebhookDeliverProcessorService.process, job);
 				}
 			}, {
 				...baseQueueOptions(this.config, QUEUE.USER_WEBHOOK_DELIVER),
@@ -377,7 +391,7 @@ export class QueueProcessorService implements OnApplicationShutdown {
 				if (this.config.sentryForBackend) {
 					return Sentry.startSpan({ name: 'Queue: SystemWebhookDeliver' }, () => this.systemWebhookDeliverProcessorService.process(job));
 				} else {
-					return this.systemWebhookDeliverProcessorService.process(job);
+					return runProcessorWithTimer('systemwebhookdeliver', this.systemWebhookDeliverProcessorService.process, job);
 				}
 			}, {
 				...baseQueueOptions(this.config, QUEUE.SYSTEM_WEBHOOK_DELIVER),
@@ -427,7 +441,7 @@ export class QueueProcessorService implements OnApplicationShutdown {
 				if (this.config.sentryForBackend) {
 					return Sentry.startSpan({ name: 'Queue: Relationship: ' + job.name }, () => processer(job));
 				} else {
-					return processer(job);
+					return runProcessorWithTimer('relationship', processer, job);
 				}
 			}, {
 				...baseQueueOptions(this.config, QUEUE.RELATIONSHIP),
@@ -472,7 +486,7 @@ export class QueueProcessorService implements OnApplicationShutdown {
 				if (this.config.sentryForBackend) {
 					return Sentry.startSpan({ name: 'Queue: ObjectStorage: ' + job.name }, () => processer(job));
 				} else {
-					return processer(job);
+					return runProcessorWithTimer('objectstorage', processer, job);
 				}
 			}, {
 				...baseQueueOptions(this.config, QUEUE.OBJECT_STORAGE),
@@ -505,7 +519,7 @@ export class QueueProcessorService implements OnApplicationShutdown {
 				if (this.config.sentryForBackend) {
 					return Sentry.startSpan({ name: 'Queue: EndedPollNotification' }, () => this.endedPollNotificationProcessorService.process(job));
 				} else {
-					return this.endedPollNotificationProcessorService.process(job);
+					return runProcessorWithTimer('endedpollnotification', this.endedPollNotificationProcessorService.process, job);
 				}
 			}, {
 				...baseQueueOptions(this.config, QUEUE.ENDED_POLL_NOTIFICATION),

--- a/packages/backend/src/server/MetricsServerService.ts
+++ b/packages/backend/src/server/MetricsServerService.ts
@@ -1,0 +1,30 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { bindThis } from '@/decorators.js';
+import {
+	collectDefaultMetrics,
+	Registry,
+} from "prom-client";
+import type { FastifyInstance, FastifyPluginOptions } from 'fastify';
+
+@Injectable()
+export class MetricsServerService {
+	private register: Registry;
+
+	constructor(
+	) {
+		this.register = new Registry()
+		collectDefaultMetrics({
+			register: this.register,
+		});
+	}
+
+ 	@bindThis
+	public createServer(fastify: FastifyInstance, options: FastifyPluginOptions, done: (err?: Error) => void) {
+		fastify.get('/', async (request, reply) => {
+			reply.code(200).send(
+				await this.register.metrics()
+			);
+		});
+		done()
+	}
+}

--- a/packages/backend/src/server/MetricsServerService.ts
+++ b/packages/backend/src/server/MetricsServerService.ts
@@ -1,18 +1,18 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { bindThis } from '@/decorators.js';
 import {
+	AggregatorRegistry,
 	collectDefaultMetrics,
-	Registry,
 } from "prom-client";
 import type { FastifyInstance, FastifyPluginOptions } from 'fastify';
 
 @Injectable()
 export class MetricsServerService {
-	private register: Registry;
+	private register: AggregatorRegistry;
 
 	constructor(
 	) {
-		this.register = new Registry()
+		this.register = new AggregatorRegistry()
 		collectDefaultMetrics({
 			register: this.register,
 		});
@@ -22,7 +22,7 @@ export class MetricsServerService {
 	public createServer(fastify: FastifyInstance, options: FastifyPluginOptions, done: (err?: Error) => void) {
 		fastify.get('/', async (request, reply) => {
 			reply.code(200).send(
-				await this.register.metrics()
+				await this.register.clusterMetrics()
 			);
 		});
 		done()

--- a/packages/backend/src/server/ServerModule.ts
+++ b/packages/backend/src/server/ServerModule.ts
@@ -9,6 +9,7 @@ import { CoreModule } from '@/core/CoreModule.js';
 import { ApiCallService } from './api/ApiCallService.js';
 import { FileServerService } from './FileServerService.js';
 import { HealthServerService } from './HealthServerService.js';
+import { MetricsServerService } from './MetricsServerService.js';
 import { NodeinfoServerService } from './NodeinfoServerService.js';
 import { ServerService } from './ServerService.js';
 import { WellKnownServerService } from './WellKnownServerService.js';
@@ -60,6 +61,7 @@ import { ReversiGameChannelService } from './api/stream/channels/reversi-game.js
 		ClientLoggerService,
 		FeedService,
 		HealthServerService,
+		MetricsServerService,
 		UrlPreviewService,
 		ActivityPubServerService,
 		FileServerService,

--- a/packages/backend/src/server/ServerService.ts
+++ b/packages/backend/src/server/ServerService.ts
@@ -29,6 +29,7 @@ import { StreamingApiServerService } from './api/StreamingApiServerService.js';
 import { WellKnownServerService } from './WellKnownServerService.js';
 import { FileServerService } from './FileServerService.js';
 import { HealthServerService } from './HealthServerService.js';
+import { MetricsServerService } from './MetricsServerService.js';
 import { ClientServerService } from './web/ClientServerService.js';
 import { OpenApiServerService } from './api/openapi/OpenApiServerService.js';
 import { MastodonApiServerService } from './api/mastodon/MastodonApiServerService.js';
@@ -65,6 +66,7 @@ export class ServerService implements OnApplicationShutdown {
 		private nodeinfoServerService: NodeinfoServerService,
 		private fileServerService: FileServerService,
 		private healthServerService: HealthServerService,
+		private metricsServerService: MetricsServerService,
 		private clientServerService: ClientServerService,
 		private globalEventService: GlobalEventService,
 		private loggerService: LoggerService,
@@ -113,6 +115,8 @@ export class ServerService implements OnApplicationShutdown {
 		fastify.register(this.wellKnownServerService.createServer);
 		fastify.register(this.oauth2ProviderService.createServer, { prefix: '/oauth' });
 		fastify.register(this.healthServerService.createServer, { prefix: '/healthz' });
+
+		fastify.register(this.metricsServerService.createServer, { prefix: '/metrics' });
 
 		fastify.get<{ Params: { path: string }; Querystring: { static?: any; badge?: any; }; }>('/emoji/:path(.*)', async (request, reply) => {
 			const path = request.params.path;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,6 +355,9 @@ importers:
       probe-image-size:
         specifier: 7.2.3
         version: 7.2.3
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       promise-limit:
         specifier: 2.7.0
         version: 2.7.0
@@ -6035,6 +6038,9 @@ packages:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
 
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -10001,6 +10007,10 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   promise-limit@2.7.0:
     resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
@@ -10995,6 +11005,9 @@ packages:
     resolution: {integrity: sha512-+HRtZ40Vc+6YfCDWCeAsixwxJgMbPY4HHuTgzPYH3JXvqHWUlsCfy+ylXlAKhFNcuLp4xVeWeFBUhDk+7KYUvQ==}
     engines: {node: '>=14.16'}
 
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
+
   telejson@7.2.0:
     resolution: {integrity: sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==}
 
@@ -11146,7 +11159,6 @@ packages:
 
   ts-case-convert@2.0.2:
     resolution: {integrity: sha512-vdKfx1VAdpvEBOBv5OpVu5ZFqRg9HdTI4sYt6qqMeICBeNyXvitrarCnFWNDAki51IKwCyx+ZssY46Q9jH5otA==}
-    bundledDependencies: []
 
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
@@ -11657,6 +11669,9 @@ packages:
 
   vue-component-type-helpers@2.0.29:
     resolution: {integrity: sha512-58i+ZhUAUpwQ+9h5Hck0D+jr1qbYl4voRt5KffBx8qzELViQ4XdT/Tuo+mzq8u63teAG8K0lLaOiL5ofqW38rg==}
+
+  vue-component-type-helpers@2.1.4:
+    resolution: {integrity: sha512-aVqB3KxwpM76cYRkpnezl1J62E/1omzHQfx1yuz7zcbxmzmP/PeSgI20NEmkdeGnjZPVzm0V9fB4ZyRu5BBj4A==}
 
   vue-demi@0.14.7:
     resolution: {integrity: sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==}
@@ -16327,7 +16342,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.34(typescript@5.5.4)
-      vue-component-type-helpers: 2.0.29
+      vue-component-type-helpers: 2.1.4
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -16346,7 +16361,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.34(typescript@5.5.4)
-      vue-component-type-helpers: 2.0.29
+      vue-component-type-helpers: 2.1.4
 
   '@swc/cli@0.3.12(@swc/core@1.6.6)(chokidar@3.5.3)':
     dependencies:
@@ -18056,6 +18071,8 @@ snapshots:
       find-versions: 5.1.0
 
   binary-extensions@2.2.0: {}
+
+  bintrees@1.0.2: {}
 
   bl@4.1.0:
     dependencies:
@@ -22887,6 +22904,11 @@ snapshots:
 
   process@0.11.10: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      tdigest: 0.1.2
+
   promise-limit@2.7.0: {}
 
   promise-polyfill@8.3.0: {}
@@ -24030,6 +24052,10 @@ snapshots:
     dependencies:
       execa: 6.1.0
 
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
+
   telejson@7.2.0:
     dependencies:
       memoizerific: 1.11.3
@@ -24641,6 +24667,8 @@ snapshots:
   vue-component-type-helpers@2.0.16: {}
 
   vue-component-type-helpers@2.0.29: {}
+
+  vue-component-type-helpers@2.1.4: {}
 
   vue-demi@0.14.7(vue@3.4.34(typescript@5.5.4)):
     dependencies:


### PR DESCRIPTION
This is a continuation of [this PR](https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/613), originyally raised against sharkey.

<!-- Thanks for taking the time to make Sharkey better!  -->

**What does this PR do?**

Adds a Prometheus compatible `/metrics` endpoint.

This is not finished yet, but I'm opening it already to collect feedback / recommendations.

Still missing: 
* [x] collect metrics for all node processes (`node:cluster`)
* [ ] Add some form of access-control on the endpoint
* [ ] Queue status metrics (waiting/delayed/errors per queue)
* [ ] Per-route request metrics (as implemented by  [fastify-metrics](https://github.com/SkeLLLa/fastify-metrics))
